### PR TITLE
tied in access token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "dev": true,
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.1.0",
@@ -156,6 +155,16 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -179,11 +188,35 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
     "atob": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.0.3.tgz",
       "integrity": "sha1-GcenYEc3dEaPILLS0DNyrX1Mv10=",
       "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "1.4.1",
+        "is-buffer": "1.1.6"
+      }
     },
     "babel-cli": {
       "version": "6.26.0",
@@ -926,6 +959,15 @@
         }
       }
     },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
@@ -946,6 +988,14 @@
         "qs": "6.5.1",
         "raw-body": "2.3.2",
         "type-is": "1.6.16"
+      }
+    },
+    "boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.2.1"
       }
     },
     "boxen": {
@@ -1093,6 +1143,11 @@
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
       "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
       "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
       "version": "4.1.2",
@@ -1277,8 +1332,7 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -1309,7 +1363,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -1459,11 +1512,37 @@
         "which": "1.3.0"
       }
     },
+    "cryptiles": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.2.0"
+      },
+      "dependencies": {
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.1"
+          }
+        }
+      }
+    },
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
     },
     "debug": {
       "version": "2.6.9",
@@ -1544,8 +1623,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
@@ -1600,6 +1678,15 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -1965,8 +2052,7 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2009,17 +2095,20 @@
         "is-extglob": "1.0.0"
       }
     },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-      "dev": true
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2101,6 +2190,24 @@
         "write": "0.2.1"
       }
     },
+    "follow-redirects": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.4.1.tgz",
+      "integrity": "sha512-uxYePVPogtya1ktGnAAXOacnbIuRMB4dkvqeNz2qTtTQsuzSfbDolV+wMMKxAmCx0bLgAKLbBOkjItMbbkR1vg==",
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2114,6 +2221,11 @@
       "requires": {
         "for-in": "1.0.2"
       }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "1.0.0-rc4",
@@ -2196,6 +2308,14 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
     },
     "glob": {
       "version": "7.1.2",
@@ -2294,6 +2414,20 @@
       "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
+      }
+    },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
@@ -2377,11 +2511,27 @@
         }
       }
     },
+    "hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.1",
+        "sntp": "2.1.0"
+      }
+    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
+    },
+    "hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -2419,6 +2569,16 @@
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
           "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
         }
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.1"
       }
     },
     "iconv-lite": {
@@ -2825,6 +2985,11 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -2851,6 +3016,11 @@
         "isarray": "1.0.0"
       }
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -2871,16 +3041,26 @@
         "esprima": "4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2888,10 +3068,26 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "keygrip": {
       "version": "1.0.2",
@@ -3173,6 +3369,11 @@
           }
         }
       }
+    },
+    "moment": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
     },
     "ms": {
       "version": "2.0.0",
@@ -3652,6 +3853,11 @@
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
       "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
     },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4038,6 +4244,11 @@
         "through": "2.3.8"
       }
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
     "pg": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/pg/-/pg-7.4.1.tgz",
@@ -4235,6 +4446,11 @@
       "requires": {
         "ps-tree": "1.1.0"
       }
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
       "version": "6.5.1",
@@ -4495,6 +4711,47 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
         "is-finite": "1.0.2"
+      }
+    },
+    "request": {
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          }
+        }
       }
     },
     "require-uncached": {
@@ -4835,6 +5092,14 @@
         "kind-of": "3.2.2"
       }
     },
+    "sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "requires": {
+        "hoek": "4.2.1"
+      }
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -4922,6 +5187,21 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "sshpk": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -5050,6 +5330,11 @@
         }
       }
     },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -5092,6 +5377,62 @@
         "mime": "1.4.1",
         "qs": "6.5.1",
         "readable-stream": "2.3.5"
+      }
+    },
+    "supertest": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.0.0.tgz",
+      "integrity": "sha1-jUu2j9GDDuBwM7HFpamkAhyWUpY=",
+      "dev": true,
+      "requires": {
+        "methods": "1.1.2",
+        "superagent": "3.8.2"
+      },
+      "dependencies": {
+        "cookiejar": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+          "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          }
+        },
+        "superagent": {
+          "version": "3.8.2",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
+          "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "cookiejar": "2.1.1",
+            "debug": "3.1.0",
+            "extend": "3.0.1",
+            "form-data": "2.3.2",
+            "formidable": "1.2.1",
+            "methods": "1.1.2",
+            "mime": "1.4.1",
+            "qs": "6.5.1",
+            "readable-stream": "2.3.5"
+          }
+        }
       }
     },
     "supports-color": {
@@ -5235,10 +5576,32 @@
         "nopt": "1.0.10"
       }
     },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -5528,6 +5891,16 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
     },
     "which": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/reganmeloche/spotify-rating#readme",
   "dependencies": {
+    "axios": "^0.18.0",
     "babel-cli": "^6.26.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
@@ -33,9 +34,11 @@
     "body-parser": "^1.18.2",
     "cookie-session": "^2.0.0-beta.3",
     "express": "^4.16.2",
+    "moment": "^2.21.0",
     "passport": "^0.4.0",
     "passport-spotify": "^1.0.0",
     "pg": "^7.4.1",
+    "request": "^2.85.0",
     "uuid": "^3.2.1"
   },
   "devDependencies": {
@@ -46,6 +49,7 @@
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-import": "^2.9.0",
     "mocha": "^5.0.5",
-    "nodemon": "^1.17.2"
+    "nodemon": "^1.17.2",
+    "supertest": "^3.0.0"
   }
 }

--- a/src/dal/init.sql
+++ b/src/dal/init.sql
@@ -3,7 +3,7 @@ CREATE TABLE public.users
     user_id text not null,
     profile_id text NOT NULL,
     email text not null,
-    join_date timestamp not null, 
+    join_date timestamp with time zone not null, 
     CONSTRAINT users_pkey PRIMARY KEY (user_id)
 )
 WITH (
@@ -14,15 +14,16 @@ TABLESPACE pg_default;
 ALTER TABLE public.users
     OWNER to postgres;
 
+--------------------------------
 
 CREATE TABLE public.user_ratings
 (
-    user_id text not null references users(user_id),
+    user_id text not null references users(user_id) ON DELETE CASCADE,
     rating_id text NOT NULL,
     album_name text not null,
     artist text not null,
     rating SMALLINT not null,
-    create_date timestamp not null, 
+    create_date timestamp with time zone not null, 
     comments text,
     fave_songs text[],
     CONSTRAINT ratings_pkey PRIMARY KEY (user_id, rating_id)
@@ -35,6 +36,27 @@ TABLESPACE pg_default;
 
 ALTER TABLE public.user_ratings
     OWNER to postgres;
+
+---------------------------------
+
+CREATE TABLE public.tokens
+(
+    user_id text not null references users(user_id) ON DELETE CASCADE,
+    access_token text NOT NULL,
+    access_token_expiry timestamp with time zone not null,
+    refresh_token text not null,
+    refresh_token_expiry timestamp with time zone not null,
+    CONSTRAINT tokens_pkey PRIMARY KEY (user_id)
+
+)
+WITH (
+    OIDS = FALSE
+)
+TABLESPACE pg_default;
+
+ALTER TABLE public.tokens
+    OWNER to postgres;
+
 
 
 

--- a/src/dal/token.js
+++ b/src/dal/token.js
@@ -1,0 +1,63 @@
+import { queryNone, queryOne } from './sqlHelper';
+
+export default class Token {
+  static async upsert(model) {
+    const myQuery = `
+      INSERT INTO tokens (
+        user_id,
+        access_token,
+        access_token_expiry,
+        refresh_token,
+        refresh_token_expiry
+      )
+      VALUES ($1, $2, $3, $4, $5)
+      ON CONFLICT (user_id) DO UPDATE 
+      SET access_token = EXCLUDED.access_token,
+          access_token_expiry = EXCLUDED.access_token_expiry,
+          refresh_token = EXCLUDED.refresh_token,
+          refresh_token_Expiry = EXCLUDED.refresh_token_expiry;
+    `;
+    const qVals = [
+      model.userId,
+      model.accessToken,
+      model.accessTokenExpiry,
+      model.refreshToken,
+      model.refreshTokenExpiry,
+    ];
+    return queryNone(myQuery, qVals);
+  }
+
+  static async getByUserId(userId) {
+    let result = null;
+    const myQuery = `
+      SELECT * 
+      FROM tokens
+      WHERE user_id = $1;
+    `;
+    const qVals = [userId];
+    const dbResult = await queryOne(myQuery, qVals);
+    if (dbResult) {
+      result = Token.convert(dbResult);
+    }
+    return result;
+  }
+
+  static async deleteByUserId(userId) {
+    const myQuery = `
+      DELETE FROM tokens
+      WHERE user_id = $1;
+    `;
+    const qVals = [userId];
+    await queryOne(myQuery, qVals);
+  }
+
+  static convert(dbModel) {
+    return {
+      userId: dbModel.user_id,
+      accessToken: dbModel.access_token,
+      accessTokenExpiry: dbModel.access_token_expiry,
+      refreshToken: dbModel.refresh_token,
+      refreshTokenExpiry: dbModel.refresh_token_expiry,
+    };
+  }
+}

--- a/src/dal/user.js
+++ b/src/dal/user.js
@@ -1,7 +1,7 @@
 import { queryNone, queryOne } from './sqlHelper';
 
 export default class User {
-  static insert(model) {
+  static async insert(model) {
     const myQuery = `
       INSERT INTO users (
         user_id,

--- a/src/dal/userRating.js
+++ b/src/dal/userRating.js
@@ -1,7 +1,7 @@
 import { queryAll, queryNone, queryOne } from './sqlHelper';
 
 export default class UserRating {
-  static insert(userId, model) {
+  static async insert(userId, model) {
     const myQuery = `
       INSERT INTO user_ratings (
         user_id,
@@ -28,7 +28,7 @@ export default class UserRating {
     return queryNone(myQuery, qVals);
   }
 
-  static update(userId, ratingId, model) {
+  static async update(userId, ratingId, model) {
     const myQuery = `
       UPDATE user_ratings 
       SET album_name = $3,

--- a/src/handlers/rating.js
+++ b/src/handlers/rating.js
@@ -1,12 +1,12 @@
 import Ratings from '../lib/rating';
 import { NotFound, ValidationError } from '../lib/errors';
-import { handleError } from '../lib/utilities';
+import { handleError, ensureAuthenticated } from '../lib/utilities';
 
 // Will probably eventually get the user from the header
 export default function (app) {
-  app.post('/rating', async (req, res) => {
+  app.post('/rating', ensureAuthenticated, async (req, res) => {
     try {
-      const result = await Ratings.create(req.query.user_id, req.body);
+      const result = await Ratings.create(req.user.userId, req.body);
       res.status(201).send(result);
     } catch (err) {
       handleError(err);
@@ -17,9 +17,9 @@ export default function (app) {
     }
   });
 
-  app.get('/rating', async (req, res) => {
+  app.get('/rating', ensureAuthenticated, async (req, res) => {
     try {
-      const result = await Ratings.getAll(req.query.user_id);
+      const result = await Ratings.getAll(req.user.userId);
       res.status(200).send(result);
     } catch (err) {
       handleError(err);
@@ -27,9 +27,9 @@ export default function (app) {
     }
   });
 
-  app.get('/rating/:rating_id', async (req, res) => {
+  app.get('/rating/:rating_id', ensureAuthenticated, async (req, res) => {
     try {
-      const result = await Ratings.getById(req.query.user_id, req.params.rating_id);
+      const result = await Ratings.getById(req.user.userId, req.params.rating_id);
       res.status(200).send(result);
     } catch (err) {
       handleError(err);
@@ -40,9 +40,9 @@ export default function (app) {
     }
   });
 
-  app.put('/rating/:rating_id', async (req, res) => {
+  app.put('/rating/:rating_id', ensureAuthenticated, async (req, res) => {
     try {
-      const result = await Ratings.update(req.query.user_id, req.params.rating_id, req.body);
+      const result = await Ratings.update(req.user.userId, req.params.rating_id, req.body);
       res.status(200).send(result);
     } catch (err) {
       handleError(err);
@@ -53,9 +53,9 @@ export default function (app) {
     }
   });
 
-  app.delete('/rating/:rating_id', async (req, res) => {
+  app.delete('/rating/:rating_id', ensureAuthenticated, async (req, res) => {
     try {
-      await Ratings.deleteRating(req.query.user_id, req.params.rating_id);
+      await Ratings.deleteRating(req.user.userId, req.params.rating_id);
       res.status(200).send();
     } catch (err) {
       handleError(err);

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -9,3 +9,9 @@ export function ValidationError(message) {
   this.stack = (new Error()).stack;
 }
 ValidationError.prototype = Object.create(Error.prototype);
+
+export function AuthError(message) {
+  this.message = message || 'Authentication Error!';
+  this.stack = (new Error()).stack;
+}
+ValidationError.prototype = Object.create(Error.prototype);

--- a/src/lib/passport.js
+++ b/src/lib/passport.js
@@ -31,6 +31,9 @@ passport.use(new SpotifyStrategy(
       user = await Users.findOrCreate({
         profileId: profile.id,
         email: profile.emails[0].value,
+        accessToken,
+        refreshToken,
+        expiresIn,
       });
     } catch (error) {
       err = error;

--- a/src/lib/user.js
+++ b/src/lib/user.js
@@ -1,6 +1,10 @@
 import uuid from 'uuid/v4';
+import axios from 'axios';
+import moment from 'moment';
 import UsersDAL from '../dal/user';
-import { NotFound } from '../lib/errors';
+import TokensDAL from '../dal/token';
+import { NotFound, AuthError } from '../lib/errors';
+import keys from '../../config/keys';
 
 export default class Users {
   static async findOrCreate(model) {
@@ -18,13 +22,25 @@ export default class Users {
   }
 
   static async create(model) {
+    // Save user
     const newUser = {
       userId: uuid(),
       email: model.email,
       profileId: model.profileId,
-      joinDate: new Date(),
+      joinDate: moment().format(),
     };
     await UsersDAL.insert(newUser);
+
+    // Save token info
+    const accessTokenExpiry = moment().add(model.expiresIn, 'seconds').format();
+    const newToken = {
+      userId: newUser.userId,
+      accessToken: model.accessToken,
+      refreshToken: model.refreshToken,
+      accessTokenExpiry,
+      refreshTokenExpiry: accessTokenExpiry, // change this
+    };
+    await TokensDAL.upsert(newToken);
     return newUser;
   }
 
@@ -46,5 +62,57 @@ export default class Users {
 
   static async deleteUser(userId) {
     await UsersDAL.deleteByUserId(userId);
+  }
+
+  static async checkValidToken(userId) {
+    let result = null;
+    const token = await TokensDAL.getByUserId(userId);
+    if (token) {
+      if (moment(token.accessTokenExpiry) > moment()) {
+        result = token.accessToken;
+      } else {
+        const newToken = await Users.refreshToken(token);
+        result = newToken.accessToken;
+      }
+      return result;
+    }
+    throw new AuthError('Access token not found');
+  }
+
+  // Use refresh token to request a new access token
+  static async refreshToken(token) {
+    let result = null;
+    try {
+      // Make call to spotify account api with refresh token
+      const res = await axios({
+        method: 'post',
+        url: 'https://accounts.spotify.com/api/token',
+        params: {
+          client_id: keys.clientId,
+          client_secret: keys.clientSecret,
+          grant_type: 'refresh_token',
+          refresh_token: token.refreshToken,
+        },
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      });
+
+      // Build and save new token
+      const body = res.data;
+      const accessTokenExpiry = moment().add(body.expires_in, 'seconds').format();
+      const newToken = {
+        userId: token.userId,
+        accessToken: body.access_token,
+        accessTokenExpiry,
+        refreshToken: body.refresh_token || token.refreshToken,
+        refreshTokenExpiry: accessTokenExpiry, // This is not currently used
+      };
+      await TokensDAL.upsert(newToken);
+      result = newToken;
+    } catch (err) {
+      throw new AuthError('Could not refresh token');
+    }
+    return result;
   }
 }

--- a/src/lib/utilities.js
+++ b/src/lib/utilities.js
@@ -1,4 +1,5 @@
 import keys from '../../config/keys';
+import Users from '../lib/user';
 
 // eslint-disable-next-line  import/prefer-default-export
 export function handleError(err) {
@@ -6,5 +7,22 @@ export function handleError(err) {
   if (keys.displayError) {
     // eslint-disable-next-line no-console
     console.log('ERROR LOG EVENT:', err);
+  }
+}
+
+export function ensureAuthenticated(req, res, next) {
+  if (req.isAuthenticated()) {
+    next();
+  } else {
+    res.redirect('/');
+  }
+}
+
+export async function getToken(req, res, next) {
+  if (req.isAuthenticated()) {
+    req.validToken = await Users.checkValidToken(req.user.userId);
+    next();
+  } else {
+    res.redirect('/');
   }
 }

--- a/test/test_rating.js
+++ b/test/test_rating.js
@@ -16,6 +16,9 @@ const testRating = {
 let createdRating;
 let userId;
 
+// Tests are broken right now
+// Need a way to authenticate throughout the tests
+
 describe('Set up user', () => {
   const testUser = {
     profileId: 'abcd1234',

--- a/test/test_user.js
+++ b/test/test_user.js
@@ -10,6 +10,9 @@ chai.use(chaiHttp);
 const testUser = {
   profileId: 'abcd1234',
   email: 'test@test.com',
+  accessToken: 'fake_access_token',
+  expiresIn: 3200,
+  refreshToken: 'fake_refresh_token',
 };
 let createdUser;
 


### PR DESCRIPTION
- save the access token, expiry time, and refresh token to a new table
- these can be looked up when we need to call spotify api (/profile endpoint is proof of concept)
- getToken middleware does the following
-- ensures user is authenticated
-- retrieves token info
-- checks if access token has expired
-- if no, then use it
-- if yes, then use refresh token to call spotify api and re-save it

- token properties are part of the user creation object now. Maybe instead of passing the properties, pass them nested inside a token object
- this also breaks the rating tests. Need to find a way to have the user authenticated throughout the test